### PR TITLE
Add materialized views for all API endpoints

### DIFF
--- a/server/create_views.py
+++ b/server/create_views.py
@@ -1,0 +1,321 @@
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+
+def create_all_views(conn: Connection) -> None:
+    _create_mv_game_week_matches(conn)
+    _create_mv_high_risk_players(conn)
+    _create_mv_trending_risk_players(conn)
+    _create_mv_teams_overview(conn)
+    _create_mv_search_players(conn)
+    _create_mv_team_player_list(conn)
+    _create_mv_player_card(conn)
+    _create_mv_injury_analysis(conn)
+    _create_mv_reported_injuries(conn)
+    print("  all materialized views created")
+
+
+def _create_mv_game_week_matches(conn: Connection) -> None:
+    conn.execute(text("""
+        CREATE MATERIALIZED VIEW mv_game_week_matches AS
+        SELECT
+            ht.team_name   AS home_team_name,
+            ht.team_logo   AS home_team_logo,
+            at.team_name   AS away_team_name,
+            at.team_logo   AS away_team_logo,
+            m.match_goals_home,
+            m.match_goals_away,
+            m.home_avg_injury_risk,
+            m.away_avg_injury_risk,
+            m.match_time,
+            m.match_date,
+            m.match_is_played
+        FROM match m
+        JOIN team ht ON ht.team_id = m.home_team_id
+        JOIN team at ON at.team_id = m.away_team_id
+        JOIN season_meta sm ON m.match_game_week = sm.current_game_week
+        ORDER BY m.match_date, m.match_time
+    """))
+
+
+def _create_mv_high_risk_players(conn: Connection) -> None:
+    conn.execute(text("""
+        CREATE MATERIALIZED VIEW mv_high_risk_players AS
+        SELECT
+            p.player_id,
+            p.player_first_name,
+            p.player_last_name,
+            p.player_photo,
+            t.team_id,
+            t.team_name,
+            p.player_position,
+            p.player_injury_risk,
+            COALESCE(si.seasonal_injuries, 0) AS player_seasonal_injuries
+        FROM player p
+        JOIN team t ON t.team_id = p.team_id
+        JOIN (
+            SELECT ps.player_id
+            FROM player_season ps
+            GROUP BY ps.player_id
+            HAVING MAX(ps.player_season_year) = (SELECT current_season_year FROM season_meta)
+        ) active ON active.player_id = p.player_id
+        LEFT JOIN (
+            SELECT ps2.player_id, COUNT(pi.player_injury_id) AS seasonal_injuries
+            FROM player_season ps2
+            JOIN (
+                SELECT player_id, MAX(player_season_year) AS latest_year
+                FROM player_season GROUP BY player_id
+            ) latest ON latest.player_id = ps2.player_id
+                   AND latest.latest_year = ps2.player_season_year
+            JOIN player_injury pi ON pi.player_season_id = ps2.player_season_id
+            GROUP BY ps2.player_id
+        ) si ON si.player_id = p.player_id
+        WHERE p.player_injury_risk < 0.99
+        ORDER BY p.player_injury_risk DESC
+    """))
+
+
+def _create_mv_trending_risk_players(conn: Connection) -> None:
+    conn.execute(text("""
+        CREATE MATERIALIZED VIEW mv_trending_risk_players AS
+        SELECT
+            p.player_id,
+            p.player_first_name,
+            p.player_last_name,
+            p.player_photo,
+            t.team_id,
+            t.team_name,
+            p.player_position,
+            gd.player_injury_trend,
+            COALESCE(si.seasonal_injuries, 0) AS player_seasonal_injuries
+        FROM player p
+        JOIN team t ON t.team_id = p.team_id
+        JOIN graph_data gd ON gd.player_id = p.player_id
+        LEFT JOIN (
+            SELECT ps.player_id, COUNT(pi.player_injury_id) AS seasonal_injuries
+            FROM player_season ps
+            JOIN (
+                SELECT player_id, MAX(player_season_year) AS latest_year
+                FROM player_season GROUP BY player_id
+            ) latest ON latest.player_id = ps.player_id
+                   AND latest.latest_year = ps.player_season_year
+            JOIN player_injury pi ON pi.player_season_id = ps.player_season_id
+            GROUP BY ps.player_id
+        ) si ON si.player_id = p.player_id
+        ORDER BY gd.player_injury_trend DESC
+    """))
+
+
+def _create_mv_teams_overview(conn: Connection) -> None:
+    conn.execute(text("""
+        CREATE MATERIALIZED VIEW mv_teams_overview AS
+        SELECT
+            t.team_id,
+            t.team_name,
+            t.team_logo,
+            COALESCE(ps.amount_of_players, 0)  AS amount_of_players,
+            ps.average_risk_of_injury,
+            COALESCE(inj.active_injuries, 0)   AS active_injuries
+        FROM team t
+        LEFT JOIN (
+            SELECT
+                p.team_id,
+                COUNT(p.player_id)        AS amount_of_players,
+                AVG(p.player_injury_risk) AS average_risk_of_injury
+            FROM player p
+            JOIN (
+                SELECT ps2.player_id
+                FROM player_season ps2
+                GROUP BY ps2.player_id
+                HAVING MAX(ps2.player_season_year) = (SELECT current_season_year FROM season_meta)
+            ) active ON active.player_id = p.player_id
+            WHERE p.player_injury_risk < 0.99
+            GROUP BY p.team_id
+        ) ps ON ps.team_id = t.team_id
+        LEFT JOIN (
+            SELECT p2.team_id, COUNT(pi.player_injury_id) AS active_injuries
+            FROM player p2
+            JOIN player_season ps3 ON ps3.player_id = p2.player_id
+            JOIN player_injury pi  ON pi.player_season_id = ps3.player_season_id
+            WHERE ps3.player_season_year = (SELECT current_season_year FROM season_meta)
+              AND pi.player_injury_end IS NULL
+            GROUP BY p2.team_id
+        ) inj ON inj.team_id = t.team_id
+        ORDER BY t.team_name
+    """))
+
+
+def _create_mv_search_players(conn: Connection) -> None:
+    conn.execute(text("""
+        CREATE MATERIALIZED VIEW mv_search_players AS
+        SELECT
+            p.player_id,
+            p.player_first_name,
+            p.player_last_name,
+            p.player_photo,
+            t.team_name,
+            p.player_injury_risk
+        FROM player p
+        JOIN team t ON t.team_id = p.team_id
+        JOIN (
+            SELECT ps.player_id
+            FROM player_season ps
+            GROUP BY ps.player_id
+            HAVING MAX(ps.player_season_year) = (SELECT current_season_year FROM season_meta)
+        ) active ON active.player_id = p.player_id
+        ORDER BY p.player_last_name
+    """))
+
+
+def _create_mv_team_player_list(conn: Connection) -> None:
+    conn.execute(text("""
+        CREATE MATERIALIZED VIEW mv_team_player_list AS
+        SELECT
+            p.player_id,
+            p.team_id,
+            p.player_first_name,
+            p.player_last_name,
+            p.player_injury_risk
+        FROM player p
+        JOIN (
+            SELECT ps.player_id
+            FROM player_season ps
+            GROUP BY ps.player_id
+            HAVING MAX(ps.player_season_year) = (SELECT current_season_year FROM season_meta)
+        ) active ON active.player_id = p.player_id
+        ORDER BY p.player_last_name
+    """))
+
+
+def _create_mv_player_card(conn: Connection) -> None:
+    conn.execute(text("""
+        CREATE MATERIALIZED VIEW mv_player_card AS
+        WITH latest_season AS (
+            SELECT player_id, MAX(player_season_year) AS latest_year
+            FROM player_season
+            GROUP BY player_id
+        ),
+        latest_season_stats AS (
+            SELECT ps.player_id,
+                   ps.player_season_minutes,
+                   ps.player_season_games_missed
+            FROM player_season ps
+            JOIN latest_season ls
+              ON ls.player_id = ps.player_id
+             AND ls.latest_year = ps.player_season_year
+        ),
+        season_injuries AS (
+            SELECT ps.player_id, COUNT(pi.player_injury_id) AS season_injuries
+            FROM player_season ps
+            JOIN player_injury pi ON pi.player_season_id = ps.player_season_id
+            WHERE ps.player_season_year = (SELECT current_season_year FROM season_meta)
+            GROUP BY ps.player_id
+        )
+        SELECT
+            p.player_id,
+            p.player_first_name,
+            p.player_last_name,
+            p.player_age,
+            p.player_weight,
+            p.player_height,
+            p.player_photo,
+            p.player_position,
+            p.player_kit_number,
+            p.player_injury_risk,
+            n.nation_name,
+            gd.player_injury_trend,
+            lss.player_season_minutes,
+            lss.player_season_games_missed,
+            COALESCE(si.season_injuries, 0) AS player_season_injuries
+        FROM player p
+        JOIN nation n ON n.nation_id = p.nation_id
+        LEFT JOIN graph_data gd ON gd.player_id = p.player_id
+        LEFT JOIN latest_season_stats lss ON lss.player_id = p.player_id
+        LEFT JOIN season_injuries si ON si.player_id = p.player_id
+    """))
+
+
+def _create_mv_injury_analysis(conn: Connection) -> None:
+    conn.execute(text("""
+        CREATE MATERIALIZED VIEW mv_injury_analysis AS
+        WITH latest_season AS (
+            SELECT player_id, MAX(player_season_year) AS latest_year
+            FROM player_season
+            GROUP BY player_id
+        ),
+        latest_season_stats AS (
+            SELECT ps.player_id,
+                   ps.player_season_appearences,
+                   ps.player_season_games_missed,
+                   ps.player_season_minutes
+            FROM player_season ps
+            JOIN latest_season ls
+              ON ls.player_id = ps.player_id
+             AND ls.latest_year = ps.player_season_year
+        ),
+        season_injuries AS (
+            SELECT ps.player_id, COUNT(pi.player_injury_id) AS season_injuries
+            FROM player_season ps
+            JOIN player_injury pi ON pi.player_season_id = ps.player_season_id
+            WHERE ps.player_season_year = (SELECT current_season_year FROM season_meta)
+            GROUP BY ps.player_id
+        ),
+        totals AS (
+            SELECT ps.player_id,
+                   SUM(ps.player_season_games_missed) AS total_games_missed
+            FROM player_season ps
+            GROUP BY ps.player_id
+        )
+        SELECT
+            ps.player_id,
+            COUNT(pi.player_injury_id)                                             AS total_injuries,
+            COUNT(pi.player_injury_id) FILTER (WHERE pi.player_injury_end IS NULL) AS ongoing_injuries,
+            COALESCE(si.season_injuries, 0)                                        AS season_injuries,
+            COALESCE(tot.total_games_missed, 0)                                    AS total_games_missed,
+            lss.player_season_appearences,
+            lss.player_season_games_missed                                         AS season_games_missed,
+            lss.player_season_minutes,
+            CASE
+                WHEN COUNT(pi.player_injury_id) FILTER (WHERE pi.player_injury_end IS NULL) > 0
+                    THEN 0
+                WHEN MAX(pi.player_injury_end) IS NOT NULL
+                    THEN GREATEST(0, CURRENT_DATE - MAX(pi.player_injury_end))
+                ELSE NULL
+            END AS days_since_injury
+        FROM player_season ps
+        LEFT JOIN player_injury pi    ON pi.player_season_id = ps.player_season_id
+        LEFT JOIN season_injuries si  ON si.player_id = ps.player_id
+        LEFT JOIN totals tot          ON tot.player_id = ps.player_id
+        LEFT JOIN latest_season_stats lss ON lss.player_id = ps.player_id
+        GROUP BY ps.player_id, si.season_injuries, tot.total_games_missed,
+                 lss.player_season_appearences, lss.player_season_games_missed,
+                 lss.player_season_minutes
+    """))
+
+
+def _create_mv_reported_injuries(conn: Connection) -> None:
+    conn.execute(text("""
+        CREATE MATERIALIZED VIEW mv_reported_injuries AS
+        SELECT
+            pi.player_injury_start,
+            pi.player_injury_end,
+            p.player_first_name,
+            p.player_last_name,
+            p.player_position,
+            t.team_name,
+            pi.player_injury_type,
+            pi.player_injury_region,
+            pi.player_injury_severity,
+            pi.player_injury_days_out
+        FROM player_injury pi
+        JOIN player_season ps ON ps.player_season_id = pi.player_season_id
+        JOIN (
+            SELECT player_id, MAX(player_season_year) AS latest_year
+            FROM player_season
+            GROUP BY player_id
+        ) latest ON latest.player_id = ps.player_id
+                AND latest.latest_year = ps.player_season_year
+        JOIN player p ON p.player_id = ps.player_id
+        JOIN team t   ON t.team_id = p.team_id
+        ORDER BY pi.player_injury_start DESC
+    """))

--- a/server/ingest_predictions.py
+++ b/server/ingest_predictions.py
@@ -26,6 +26,7 @@ from decimal import Decimal, InvalidOperation
 from pathlib import Path
 
 from sqlalchemy import text, insert
+from create_views import create_all_views
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -108,7 +109,19 @@ def main():
         # Defer FK checks so we can delete + re-insert in bulk without ordering issues
         conn.execute(text("SET CONSTRAINTS ALL DEFERRED"))
 
-        # ── 1. Wipe ML-derived tables ─────────────────────────────────────────
+        # ── 1. Drop materialized views (must happen before table wipe) ────────
+        print("\nDropping materialized views...")
+        for view in (
+            "mv_high_risk_players", "mv_trending_risk_players",
+            "mv_teams_overview", "mv_search_players",
+            "mv_team_player_list", "mv_player_card",
+            "mv_injury_analysis", "mv_reported_injuries",
+            "mv_game_week_matches",
+        ):
+            conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {view}"))
+        print("  views dropped")
+
+        # ── 2. Wipe ML-derived tables ─────────────────────────────────────────
         print("\nClearing ML-derived tables...")
         for tbl in ("graph_data", "player_injury", "player_season", "match",
                     "player", "team", "nation", "season_meta"):
@@ -352,6 +365,12 @@ def main():
         conn.execute(insert(SeasonMeta), [{"current_season_year": season_yr, "current_game_week": current_gw}])
         print(f"  season_meta: year={season_yr}, gw={current_gw}")
 
+        conn.commit()
+
+    # ── Create materialized views ─────────────────────────────────────────────
+    print("\nCreating materialized views...")
+    with engine.connect() as conn:
+        create_all_views(conn)
         conn.commit()
 
     # ── Row count summary ─────────────────────────────────────────────────────

--- a/server/integration/dashboard.py
+++ b/server/integration/dashboard.py
@@ -1,9 +1,6 @@
 from typing import List, TypedDict
-from sqlalchemy import func, select as sa_select
-from sqlalchemy.orm import aliased
+from sqlalchemy import text
 from sqlmodel import Session
-from database_init import Match, Team, Player, PlayerSeason, PlayerInjury, GraphData, UserFavourite
-from integration.common import get_season_meta, get_active_player_ids_sq
 
 
 class GameWeekMatches(TypedDict):
@@ -44,158 +41,81 @@ class TrendingRiskPlayer(TypedDict):
     player_seasonal_injuries: int
 
 
-def _seasonal_injuries_sq():
-    latest_season_sq = (
-        sa_select(  # type: ignore[call-overload, arg-type]
-            PlayerSeason.player_id,  # type: ignore[arg-type]
-            func.max(PlayerSeason.player_season_year).label("latest_year"),
-        )
-        .group_by(PlayerSeason.player_id)
-        .subquery("latest_season_sq")
-    )
-
-    return (
-        sa_select(  # type: ignore[call-overload, arg-type]
-            PlayerSeason.player_id,  # type: ignore[arg-type]
-            func.count(PlayerInjury.player_injury_id).label("seasonal_injuries"),  # type: ignore[arg-type]
-        )
-        .join(  # type: ignore[arg-type]
-            latest_season_sq,
-            (latest_season_sq.c.player_id == PlayerSeason.player_id) &
-            (latest_season_sq.c.latest_year == PlayerSeason.player_season_year),
-        )
-        .join(PlayerInjury, PlayerInjury.player_season_id == PlayerSeason.player_season_id)  # type: ignore[arg-type]
-        .group_by(PlayerSeason.player_id)
-        .subquery("seasonal_injuries")
-    )
-
-
 def get_game_week_matches(session: Session) -> List[GameWeekMatches]:
-    game_week = get_season_meta(session).current_game_week
-    HomeTeam = aliased(Team)
-    AwayTeam = aliased(Team)
-
-    stmt = (
-        sa_select(  # type: ignore[call-overload, arg-type]
-            HomeTeam.team_name.label("home_team_name"),  # type: ignore[attr-defined]
-            HomeTeam.team_logo.label("home_team_logo"),  # type: ignore[attr-defined]
-            AwayTeam.team_name.label("away_team_name"),  # type: ignore[attr-defined]
-            AwayTeam.team_logo.label("away_team_logo"),  # type: ignore[attr-defined]
-            Match.match_goals_home,  # type: ignore[arg-type]
-            Match.match_goals_away,  # type: ignore[arg-type]
-            Match.home_avg_injury_risk,  # type: ignore[arg-type]
-            Match.away_avg_injury_risk,  # type: ignore[arg-type]
-            Match.match_time,  # type: ignore[arg-type]
-            Match.match_date,  # type: ignore[arg-type]
-            Match.match_is_played,  # type: ignore[arg-type]
-        )
-        .join(HomeTeam, Match.home_team_id == HomeTeam.team_id) # type: ignore[arg-type]
-        .join(AwayTeam, Match.away_team_id == AwayTeam.team_id) # type: ignore[arg-type]
-        .where(Match.match_game_week == game_week)  # type: ignore[arg-type]
-        .order_by(Match.match_date, Match.match_time)  # type: ignore[arg-type]
-    )
-
-    rows = session.execute(stmt).all()
+    rows = session.execute(text("SELECT * FROM mv_game_week_matches")).mappings().all()
     return [
         {
-            "home_team_name": row.home_team_name,
-            "away_team_name": row.away_team_name,
-            "home_team_logo": row.home_team_logo,
-            "away_team_logo": row.away_team_logo,
-            "home_team_goals": row.match_goals_home if row.match_is_played else None,
-            "away_team_goals": row.match_goals_away if row.match_is_played else None,
-            "home_average_injury_risk": None if row.match_is_played else round(float(row.home_avg_injury_risk) * 100),
-            "away_average_injury_risk": None if row.match_is_played else round(float(row.away_avg_injury_risk) * 100),
-            "match_time": str(row.match_time) if row.match_time else None,
-            "match_date": str(row.match_date),
-            "match_is_played": row.match_is_played,
+            "home_team_name": row["home_team_name"],
+            "away_team_name": row["away_team_name"],
+            "home_team_logo": row["home_team_logo"],
+            "away_team_logo": row["away_team_logo"],
+            "home_team_goals": row["match_goals_home"] if row["match_is_played"] else None,
+            "away_team_goals": row["match_goals_away"] if row["match_is_played"] else None,
+            "home_average_injury_risk": None if row["match_is_played"] else round(float(row["home_avg_injury_risk"]) * 100),
+            "away_average_injury_risk": None if row["match_is_played"] else round(float(row["away_avg_injury_risk"]) * 100),
+            "match_time": str(row["match_time"]) if row["match_time"] else None,
+            "match_date": str(row["match_date"]),
+            "match_is_played": row["match_is_played"],
         }
         for row in rows
     ]
 
 
 def get_high_risk_players(session: Session, user_id: int | None = None) -> List[HighRiskPlayer]:
-    inj_sq = _seasonal_injuries_sq()
-    active_sq = get_active_player_ids_sq(session)
-
-    stmt = (
-        sa_select(  # type: ignore[call-overload, arg-type]
-            Player.player_id,  # type: ignore[arg-type]
-            Player.player_first_name,  # type: ignore[arg-type]
-            Player.player_last_name,  # type: ignore[arg-type]
-            Player.player_photo,  # type: ignore[arg-type]
-            Team.team_id,  # type: ignore[arg-type]
-            Team.team_name,  # type: ignore[arg-type]
-            Player.player_position,  # type: ignore[arg-type]
-            Player.player_injury_risk,  # type: ignore[arg-type]
-            func.coalesce(inj_sq.c.seasonal_injuries, 0).label("player_seasonal_injuries"),
-        )
-        .join(Team, Player.team_id == Team.team_id)
-        .join(active_sq, active_sq.c.player_id == Player.player_id)
-        .outerjoin(inj_sq, inj_sq.c.player_id == Player.player_id)
-        .where(Player.player_injury_risk < 0.99)  # type: ignore[arg-type]
-        .order_by(Player.player_injury_risk.desc())  # type: ignore[attr-defined]
-    )
-
     if user_id is not None:
-        stmt = stmt.join(UserFavourite, (UserFavourite.player_id == Player.player_id) & (UserFavourite.user_id == user_id))  # type: ignore[arg-type]
+        rows = session.execute(
+            text("""
+                SELECT mv.* FROM mv_high_risk_players mv
+                JOIN user_favourite uf
+                  ON uf.player_id = mv.player_id AND uf.user_id = :uid
+            """),
+            {"uid": user_id}
+        ).mappings().all()
     else:
-        stmt = stmt.where(Player.player_injury_risk > 0.50)  # type: ignore[arg-type]
-
-    rows = session.execute(stmt).all()
+        rows = session.execute(
+            text("SELECT * FROM mv_high_risk_players WHERE player_injury_risk > 0.50")
+        ).mappings().all()
     return [
         {
-            "player_id": row.player_id,
-            "player_first_name": row.player_first_name,
-            "player_last_name": row.player_last_name,
-            "player_photo": row.player_photo,
-            "team_id": row.team_id,
-            "team_name": row.team_name,
-            "player_position": row.player_position,
-            "player_injury_risk": round(float(row.player_injury_risk) * 100),
-            "player_seasonal_injuries": row.player_seasonal_injuries,
+            "player_id": row["player_id"],
+            "player_first_name": row["player_first_name"],
+            "player_last_name": row["player_last_name"],
+            "player_photo": row["player_photo"],
+            "team_id": row["team_id"],
+            "team_name": row["team_name"],
+            "player_position": row["player_position"],
+            "player_injury_risk": round(float(row["player_injury_risk"]) * 100),
+            "player_seasonal_injuries": row["player_seasonal_injuries"],
         }
         for row in rows
     ]
 
 
 def get_trending_risk_players(session: Session, user_id: int | None = None) -> List[TrendingRiskPlayer]:
-    inj_sq = _seasonal_injuries_sq()
-
-    stmt = (
-        sa_select(  # type: ignore[call-overload, arg-type]
-            Player.player_id,  # type: ignore[arg-type]
-            Player.player_first_name,  # type: ignore[arg-type]
-            Player.player_last_name,  # type: ignore[arg-type]
-            Player.player_photo,  # type: ignore[arg-type]
-            Team.team_id,  # type: ignore[arg-type]
-            Team.team_name,  # type: ignore[arg-type]
-            Player.player_position,  # type: ignore[arg-type]
-            GraphData.player_injury_trend,  # type: ignore[arg-type]
-            func.coalesce(inj_sq.c.seasonal_injuries, 0).label("player_seasonal_injuries"),
-        )
-        .join(Team, Player.team_id == Team.team_id)
-        .join(GraphData, GraphData.player_id == Player.player_id)
-        .outerjoin(inj_sq, inj_sq.c.player_id == Player.player_id)
-        .where(GraphData.player_injury_trend > 30)  # type: ignore[arg-type]
-        .order_by(GraphData.player_injury_trend.desc())  # type: ignore[attr-defined]
-    )
-
     if user_id is not None:
-        stmt = stmt.join(UserFavourite, (UserFavourite.player_id == Player.player_id) & (UserFavourite.user_id == user_id))  # type: ignore[arg-type]
-
-    rows = session.execute(stmt).all()
+        rows = session.execute(
+            text("""
+                SELECT mv.* FROM mv_trending_risk_players mv
+                JOIN user_favourite uf
+                  ON uf.player_id = mv.player_id AND uf.user_id = :uid
+            """),
+            {"uid": user_id}
+        ).mappings().all()
+    else:
+        rows = session.execute(
+            text("SELECT * FROM mv_trending_risk_players WHERE player_injury_trend > 30")
+        ).mappings().all()
     return [
         {
-            "player_id": row.player_id,
-            "player_first_name": row.player_first_name,
-            "player_last_name": row.player_last_name,
-            "player_photo": row.player_photo,
-            "team_id": row.team_id,
-            "team_name": row.team_name,
-            "player_position": row.player_position,
-            "player_injury_trend": round(float(row.player_injury_trend)),
-            "player_seasonal_injuries": row.player_seasonal_injuries,
+            "player_id": row["player_id"],
+            "player_first_name": row["player_first_name"],
+            "player_last_name": row["player_last_name"],
+            "player_photo": row["player_photo"],
+            "team_id": row["team_id"],
+            "team_name": row["team_name"],
+            "player_position": row["player_position"],
+            "player_injury_trend": round(float(row["player_injury_trend"])),
+            "player_seasonal_injuries": row["player_seasonal_injuries"],
         }
         for row in rows
     ]

--- a/server/integration/player_page.py
+++ b/server/integration/player_page.py
@@ -1,9 +1,8 @@
-from datetime import date
 from typing import List, TypedDict
-from sqlalchemy import func, select as sa_select
+from sqlalchemy import func, select as sa_select, text
 from sqlmodel import Session, select
-from database_init import Player, PlayerSeason, GraphData, Nation, PlayerInjury
-from integration.common import get_season_meta, get_active_player_ids_sq
+from database_init import PlayerSeason, GraphData, PlayerInjury
+from integration.common import get_season_meta
 
 
 class TeamPlayerList(TypedDict):
@@ -107,86 +106,45 @@ class InjuryAnalysis(TypedDict):
 
 
 def get_team_player_list(team_id: int, session: Session) -> List[TeamPlayerList]:
-    active_sq = get_active_player_ids_sq(session)
     rows = session.execute(
-        sa_select(  # type: ignore[call-overload, arg-type]
-            Player.player_id,  # type: ignore[arg-type]
-            Player.player_first_name,  # type: ignore[arg-type]
-            Player.player_last_name,  # type: ignore[arg-type]
-            Player.player_injury_risk,  # type: ignore[arg-type]
-        )
-        .join(active_sq, active_sq.c.player_id == Player.player_id)
-        .where(Player.team_id == team_id)  # type: ignore[arg-type]
-        .order_by(Player.player_last_name)  # type: ignore[attr-defined]
-    ).all()
-
+        text("SELECT * FROM mv_team_player_list WHERE team_id = :tid"),
+        {"tid": team_id}
+    ).mappings().all()
     return [
         {
-            "player_id": row.player_id,
-            "player_first_name": row.player_first_name,
-            "player_last_name": row.player_last_name,
-            "player_injury_risk": "injured" if float(row.player_injury_risk) >= 0.99 else round(float(row.player_injury_risk) * 100),
+            "player_id": row["player_id"],
+            "player_first_name": row["player_first_name"],
+            "player_last_name": row["player_last_name"],
+            "player_injury_risk": "injured" if float(row["player_injury_risk"]) >= 0.99 else round(float(row["player_injury_risk"]) * 100),
         }
         for row in rows
     ]
 
 
 def get_player_card(player_id: int, session: Session) -> PlayerCard | None:
-    result = session.execute(
-        sa_select(  # type: ignore[call-overload, arg-type]
-            Player.player_first_name,  # type: ignore[arg-type]
-            Player.player_last_name,  # type: ignore[arg-type]
-            Player.player_age,  # type: ignore[arg-type]
-            Player.player_weight,  # type: ignore[arg-type]
-            Player.player_height,  # type: ignore[arg-type]
-            Player.player_photo,  # type: ignore[arg-type]
-            Player.player_position,  # type: ignore[arg-type]
-            Player.player_kit_number,  # type: ignore[arg-type]
-            Player.player_injury_risk,  # type: ignore[arg-type]
-            Nation.nation_name,  # type: ignore[arg-type]
-        )
-        .join(Nation, Player.nation_id == Nation.nation_id)  # type: ignore[arg-type]
-        .where(Player.player_id == player_id)  # type: ignore[arg-type]
-    ).one_or_none()
-
-    if not result:
+    row = session.execute(
+        text("SELECT * FROM mv_player_card WHERE player_id = :pid"),
+        {"pid": player_id}
+    ).mappings().one_or_none()
+    if not row:
         return None
-
-    latest_season = session.exec(
-        select(PlayerSeason)
-        .where(PlayerSeason.player_id == player_id)  # type: ignore[arg-type]
-        .order_by(PlayerSeason.player_season_year.desc())  # type: ignore[attr-defined]
-    ).first()
-
-    season_injuries = 0
-    if latest_season:
-        season_injuries = session.execute(
-            sa_select(func.count(PlayerInjury.player_injury_id))  # type: ignore[arg-type]
-            .where(PlayerInjury.player_season_id == latest_season.player_season_id)  # type: ignore[arg-type]
-        ).scalar() or 0
-
-    graph = session.exec(
-        select(GraphData).where(GraphData.player_id == player_id)  # type: ignore[arg-type]
-    ).first()
-
-    injury_risk = float(result.player_injury_risk)
-
+    injury_risk = float(row["player_injury_risk"])
     return {
-        "player_first_name": result.player_first_name,
-        "player_last_name": result.player_last_name,
-        "player_age": result.player_age,
-        "player_weight": result.player_weight,
-        "player_height": result.player_height,
-        "player_photo": result.player_photo,
-        "player_position": result.player_position,
-        "player_kit_number": result.player_kit_number,
-        "nation_name": result.nation_name,
+        "player_first_name": row["player_first_name"],
+        "player_last_name": row["player_last_name"],
+        "player_age": row["player_age"],
+        "player_weight": row["player_weight"],
+        "player_height": row["player_height"],
+        "player_photo": row["player_photo"],
+        "player_position": row["player_position"],
+        "player_kit_number": row["player_kit_number"],
+        "nation_name": row["nation_name"],
         "player_injury_risk": round(injury_risk * 100),
         "player_injury_status": "injured" if injury_risk >= 0.99 else "available",
-        "player_injury_trend": round(float(graph.player_injury_trend)) if graph else 0,
-        "player_season_injuries": season_injuries,
-        "player_season_minutes": latest_season.player_season_minutes if latest_season else 0,
-        "player_season_missed_games": latest_season.player_season_games_missed if latest_season else 0,
+        "player_injury_trend": round(float(row["player_injury_trend"])) if row["player_injury_trend"] else 0,
+        "player_season_injuries": row["player_season_injuries"],
+        "player_season_minutes": row["player_season_minutes"],
+        "player_season_missed_games": row["player_season_games_missed"],
     }
 
 
@@ -277,54 +235,21 @@ def get_injury_history(player_id: int, session: Session) -> List[InjuryHistory]:
 
 
 def get_injury_analysis(player_id: int, session: Session) -> InjuryAnalysis:
-    current_season_year = get_season_meta(session).current_season_year
-
-    total_stats = session.execute(
-        sa_select(  # type: ignore[call-overload, arg-type]
-            func.count(PlayerInjury.player_injury_id).label("total_injuries"),  # type: ignore[arg-type]
-            func.max(PlayerInjury.player_injury_end).label("last_injury_date"),  # type: ignore[arg-type]
-            func.count(PlayerInjury.player_injury_id).filter(PlayerInjury.player_injury_end == None).label("ongoing_injuries"),  # type: ignore[arg-type]
-        )
-        .join(PlayerSeason, PlayerInjury.player_season_id == PlayerSeason.player_season_id)  # type: ignore[arg-type]
-        .where(PlayerSeason.player_id == player_id)  # type: ignore[arg-type]
-    ).one()
-
-    season_injuries = session.execute(
-        sa_select(func.count(PlayerInjury.player_injury_id))  # type: ignore[arg-type]
-        .join(PlayerSeason, PlayerInjury.player_season_id == PlayerSeason.player_season_id)  # type: ignore[arg-type]
-        .where(PlayerSeason.player_id == player_id)  # type: ignore[arg-type]
-        .where(PlayerSeason.player_season_year == current_season_year)  # type: ignore[arg-type]  # type: ignore[arg-type]
-    ).scalar() or 0
-
-    season_agg = session.execute(
-        sa_select(  # type: ignore[call-overload, arg-type]
-            func.sum(PlayerSeason.player_season_games_missed).label("total_games_missed"),  # type: ignore[arg-type]
-        ).where(PlayerSeason.player_id == player_id)  # type: ignore[arg-type]
-    ).one()
-
-    current_season = session.exec(
-        select(PlayerSeason)
-        .where(PlayerSeason.player_id == player_id)  # type: ignore[arg-type]
-        .where(PlayerSeason.player_season_year == current_season_year)  # type: ignore[arg-type]
-    ).first()
+    row = session.execute(
+        text("SELECT * FROM mv_injury_analysis WHERE player_id = :pid"),
+        {"pid": player_id}
+    ).mappings().one_or_none()
 
     avg_games_played = None
-    if current_season:
-        total_matches = current_season.player_season_appearences + current_season.player_season_games_missed
+    if row:
+        total_matches = row["player_season_appearences"] + row["season_games_missed"]
         if total_matches > 0:
-            avg_games_played = round(current_season.player_season_minutes / total_matches, 1)
-
-    if total_stats.ongoing_injuries > 0:
-        days_since = 0
-    elif total_stats.last_injury_date:
-        days_since = max(0, (date.today() - total_stats.last_injury_date).days)
-    else:
-        days_since = None
+            avg_games_played = round(row["player_season_minutes"] / total_matches, 1)
 
     return {
-        "player_total_injuries": total_stats.total_injuries or 0,
-        "player_season_injuries": season_injuries,
-        "player_total_games_missed": season_agg.total_games_missed or 0,
-        "player_days_since_injury": days_since,
+        "player_total_injuries": row["total_injuries"] if row else 0,
+        "player_season_injuries": row["season_injuries"] if row else 0,
+        "player_total_games_missed": row["total_games_missed"] if row else 0,
+        "player_days_since_injury": row["days_since_injury"] if row else None,
         "player_average_games_played": avg_games_played,
     }

--- a/server/integration/reported_injuries.py
+++ b/server/integration/reported_injuries.py
@@ -1,7 +1,6 @@
 from typing import List, TypedDict
-from sqlalchemy import func, select as sa_select
+from sqlalchemy import text
 from sqlmodel import Session
-from database_init import Player, PlayerInjury, PlayerSeason, Team
 
 
 class InjuryList(TypedDict):
@@ -18,52 +17,19 @@ class InjuryList(TypedDict):
 
 
 def get_reported_injuries(session: Session) -> List[InjuryList]:
-    latest_season_sq = (
-        sa_select(  # type: ignore[call-overload, arg-type]
-            PlayerSeason.player_id,  # type: ignore[arg-type]
-            func.max(PlayerSeason.player_season_year).label("latest_year"),
-        )
-        .group_by(PlayerSeason.player_id)
-        .subquery("latest_season_sq")
-    )
-
-    stmt = (
-        sa_select(  # type: ignore[call-overload, arg-type]
-            PlayerInjury.player_injury_start,  # type: ignore[arg-type]
-            PlayerInjury.player_injury_end,  # type: ignore[arg-type]
-            Player.player_first_name,  # type: ignore[arg-type]
-            Player.player_last_name,  # type: ignore[arg-type]
-            Player.player_position,  # type: ignore[arg-type]
-            Team.team_name,  # type: ignore[arg-type]
-            PlayerInjury.player_injury_type,  # type: ignore[arg-type]
-            PlayerInjury.player_injury_region,  # type: ignore[arg-type]
-            PlayerInjury.player_injury_severity,  # type: ignore[arg-type]
-            PlayerInjury.player_injury_days_out,  # type: ignore[arg-type]
-        )
-        .join(PlayerSeason, PlayerInjury.player_season_id == PlayerSeason.player_season_id)  # type: ignore[arg-type]
-        .join(  # type: ignore[arg-type]
-            latest_season_sq,
-            (latest_season_sq.c.player_id == PlayerSeason.player_id) &
-            (latest_season_sq.c.latest_year == PlayerSeason.player_season_year),
-        )
-        .join(Player, Player.player_id == PlayerSeason.player_id)  # type: ignore[arg-type]
-        .join(Team, Team.team_id == Player.team_id)  # type: ignore[arg-type]
-        .order_by(PlayerInjury.player_injury_start.desc())  # type: ignore[attr-defined]
-    )
-
-    rows = session.execute(stmt).all()  # type: ignore[arg-type]
+    rows = session.execute(text("SELECT * FROM mv_reported_injuries")).mappings().all()
     return [
         {
-            "injury_date_start": str(row.player_injury_start),
-            "injury_date_end": str(row.player_injury_end) if row.player_injury_end else None,
-            "player_first_name": row.player_first_name,
-            "player_last_name": row.player_last_name,
-            "team_name": row.team_name,
-            "player_injury_diagnosis": row.player_injury_type,
-            "player_injury_region": row.player_injury_region,
-            "player_injury_severity": row.player_injury_severity,
-            "player_position": row.player_position,
-            "player_injury_days_out": row.player_injury_days_out,
+            "injury_date_start": str(row["player_injury_start"]),
+            "injury_date_end": str(row["player_injury_end"]) if row["player_injury_end"] else None,
+            "player_first_name": row["player_first_name"],
+            "player_last_name": row["player_last_name"],
+            "team_name": row["team_name"],
+            "player_injury_diagnosis": row["player_injury_type"],
+            "player_injury_region": row["player_injury_region"],
+            "player_injury_severity": row["player_injury_severity"],
+            "player_position": row["player_position"],
+            "player_injury_days_out": row["player_injury_days_out"],
         }
         for row in rows
     ]

--- a/server/integration/search.py
+++ b/server/integration/search.py
@@ -1,8 +1,7 @@
 from typing import List, TypedDict
-from sqlalchemy import select as sa_select, distinct
+from sqlalchemy import text, select as sa_select, distinct
 from sqlmodel import Session
-from database_init import Player, Team, PlayerInjury
-from integration.common import get_active_player_ids_sq
+from database_init import Team, PlayerInjury
 
 
 class SearchPlayer(TypedDict):
@@ -21,30 +20,15 @@ class SearchTeam(TypedDict):
 
 
 def get_search_players(session: Session) -> List[SearchPlayer]:
-    active_sq = get_active_player_ids_sq(session)
-
-    rows = session.execute(
-        sa_select(  # type: ignore[call-overload, arg-type]
-            Player.player_id,  # type: ignore[arg-type]
-            Player.player_first_name,  # type: ignore[arg-type]
-            Player.player_last_name,  # type: ignore[arg-type]
-            Player.player_photo,  # type: ignore[arg-type]
-            Team.team_name,  # type: ignore[arg-type]
-            Player.player_injury_risk,  # type: ignore[arg-type]
-        )
-        .join(Team, Player.team_id == Team.team_id)  # type: ignore[arg-type]
-        .join(active_sq, active_sq.c.player_id == Player.player_id)
-        .order_by(Player.player_last_name)  # type: ignore[attr-defined]
-    ).all()
-
+    rows = session.execute(text("SELECT * FROM mv_search_players")).mappings().all()
     return [
         {
-            "player_id": row.player_id,
-            "player_first_name": row.player_first_name,
-            "player_last_name": row.player_last_name,
-            "player_photo": row.player_photo,
-            "team_name": row.team_name,
-            "player_injury_risk": round(float(row.player_injury_risk) * 100),
+            "player_id": row["player_id"],
+            "player_first_name": row["player_first_name"],
+            "player_last_name": row["player_last_name"],
+            "player_photo": row["player_photo"],
+            "team_name": row["team_name"],
+            "player_injury_risk": round(float(row["player_injury_risk"]) * 100),
         }
         for row in rows
     ]

--- a/server/integration/teams.py
+++ b/server/integration/teams.py
@@ -1,8 +1,6 @@
 from typing import List, TypedDict
-from sqlalchemy import func, select as sa_select
+from sqlalchemy import text
 from sqlmodel import Session
-from database_init import Team, Player, PlayerSeason, PlayerInjury
-from integration.common import get_season_meta, get_active_player_ids_sq
 
 
 class TeamOverview(TypedDict):
@@ -16,57 +14,16 @@ class TeamOverview(TypedDict):
 
 
 def get_teams_overview(session: Session) -> List[TeamOverview]:
-    active_sq = get_active_player_ids_sq(session)
-    player_stats_sq = (
-        sa_select(  # type: ignore[call-overload, arg-type]
-            Player.team_id,
-            func.count(Player.player_id).label("amount_of_players"),
-            func.avg(Player.player_injury_risk).label("average_risk_of_injury"),
-        )
-        .join(active_sq, active_sq.c.player_id == Player.player_id)
-        .where(Player.player_injury_risk < 0.99)  # type: ignore[arg-type]
-        .group_by(Player.team_id)
-        .subquery("player_stats")
-    )
-
-    current_season_year = get_season_meta(session).current_season_year
-    injury_stats_sq = (
-        sa_select(  # type: ignore[call-overload, arg-type]
-            Player.team_id,
-            func.count(PlayerInjury.player_injury_id).label("active_injuries"),
-        )
-        .join(PlayerSeason, PlayerSeason.player_id == Player.player_id)  # type: ignore[arg-type]
-        .join(PlayerInjury, PlayerInjury.player_season_id == PlayerSeason.player_season_id)  # type: ignore[arg-type]
-        .where(PlayerSeason.player_season_year == current_season_year)  # type: ignore[arg-type]
-        .where(PlayerInjury.player_injury_end == None)  # type: ignore[arg-type]
-        .group_by(Player.team_id)
-        .subquery("injury_stats")
-    )
-
-    stmt = (
-        sa_select(  # type: ignore[call-overload, arg-type]
-            Team.team_id,  # type: ignore[arg-type]
-            Team.team_name,  # type: ignore[arg-type]
-            Team.team_logo,  # type: ignore[arg-type]
-            func.coalesce(player_stats_sq.c.amount_of_players, 0).label("amount_of_players"),
-            player_stats_sq.c.average_risk_of_injury,
-            func.coalesce(injury_stats_sq.c.active_injuries, 0).label("active_injuries"),
-        )
-        .outerjoin(player_stats_sq, player_stats_sq.c.team_id == Team.team_id)
-        .outerjoin(injury_stats_sq, injury_stats_sq.c.team_id == Team.team_id)
-        .order_by(Team.team_name)  # type: ignore[arg-type]
-    )
-
-    rows = session.execute(stmt).all()
+    rows = session.execute(text("SELECT * FROM mv_teams_overview")).mappings().all()
     return [
         {
-            "team_id": row.team_id,
-            "team_name": row.team_name,
-            "team_logo": row.team_logo,
-            "amount_of_players": row.amount_of_players,
-            "average_risk_of_injury": round(float(row.average_risk_of_injury) * 100) if row.average_risk_of_injury else None,
-            "active_injuries": row.active_injuries,
-            "percent_of_squad_injured": round(row.active_injuries / row.amount_of_players * 100) if row.amount_of_players else 0,
+            "team_id": row["team_id"],
+            "team_name": row["team_name"],
+            "team_logo": row["team_logo"],
+            "amount_of_players": row["amount_of_players"],
+            "average_risk_of_injury": round(float(row["average_risk_of_injury"]) * 100) if row["average_risk_of_injury"] else None,
+            "active_injuries": row["active_injuries"],
+            "percent_of_squad_injured": round(row["active_injuries"] / row["amount_of_players"] * 100) if row["amount_of_players"] else 0,
         }
         for row in rows
     ]


### PR DESCRIPTION
- create_views.py: 9 materialized views (game_week_matches, high_risk_players, trending_risk_players, teams_overview, search_players, team_player_list, player_card, injury_analysis, reported_injuries)
- ingestor: drops views before table wipe, recreates after commit
- dashboard/teams/search/player_page/reported_injuries: all migrated to text()+mappings() view queries; ORM join complexity removed
- trending/high-risk favourite fix: trend>30 / risk>0.50 filters only applied for anonymous queries; favourites bypass filter entirely